### PR TITLE
Update palette and add dark mode toggle

### DIFF
--- a/app/src/main/java/com/example/feeloscope/MainActivity.java
+++ b/app/src/main/java/com/example/feeloscope/MainActivity.java
@@ -1,20 +1,20 @@
 package com.example.feeloscope;
 
+import android.content.res.Configuration;
 import android.os.Bundle;
-import android.view.View;
 import android.view.Menu;
+import android.view.View;
 
-import com.google.android.material.snackbar.Snackbar;
-import com.google.android.material.navigation.NavigationView;
-
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatDelegate;
+import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
 import androidx.navigation.ui.AppBarConfiguration;
 import androidx.navigation.ui.NavigationUI;
-import androidx.drawerlayout.widget.DrawerLayout;
-import androidx.appcompat.app.AppCompatActivity;
 
 import com.example.feeloscope.databinding.ActivityMainBinding;
+import com.google.android.material.navigation.NavigationView;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -29,12 +29,11 @@ public class MainActivity extends AppCompatActivity {
         setContentView(binding.getRoot());
 
         setSupportActionBar(binding.appBarMain.toolbar);
+        updateFabIcon();
         binding.appBarMain.fab.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                Snackbar.make(view, "Replace with your own action", Snackbar.LENGTH_LONG)
-                        .setAction("Action", null)
-                        .setAnchorView(R.id.fab).show();
+                toggleTheme();
             }
         });
         DrawerLayout drawer = binding.drawerLayout;
@@ -62,5 +61,35 @@ public class MainActivity extends AppCompatActivity {
         NavController navController = Navigation.findNavController(this, R.id.nav_host_fragment_content_main);
         return NavigationUI.navigateUp(navController, mAppBarConfiguration)
                 || super.onSupportNavigateUp();
+    }
+
+    private void toggleTheme() {
+        int currentNightMode = getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
+        if (currentNightMode == Configuration.UI_MODE_NIGHT_YES) {
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
+            setFabIcon(false);
+        } else {
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
+            setFabIcon(true);
+        }
+    }
+
+    private void updateFabIcon() {
+        if (binding == null || binding.appBarMain == null) {
+            return;
+        }
+        int currentNightMode = getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
+        setFabIcon(currentNightMode == Configuration.UI_MODE_NIGHT_YES);
+    }
+
+    private void setFabIcon(boolean isNightMode) {
+        if (binding == null || binding.appBarMain == null) {
+            return;
+        }
+        if (isNightMode) {
+            binding.appBarMain.fab.setImageResource(R.drawable.ic_sun);
+        } else {
+            binding.appBarMain.fab.setImageResource(R.drawable.ic_moon);
+        }
     }
 }

--- a/app/src/main/res/drawable/ic_moon.xml
+++ b/app/src/main/res/drawable/ic_moon.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnSecondary">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,2.5c-4.14,0 -7.5,3.36 -7.5,7.5s3.36,7.5 7.5,7.5c2.01,0 3.83,-0.81 5.17,-2.13 -3.43,-0.38 -6.1,-3.3 -6.1,-6.87 0,-2.23 1.08,-4.2 2.75,-5.47 -0.6,-0.17 -1.23,-0.26 -1.82,-0.26z" />
+</vector>

--- a/app/src/main/res/drawable/ic_sun.xml
+++ b/app/src/main/res/drawable/ic_sun.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnSecondary">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,7a5,5 0 1,1 0,10 5,5 0 0,1 0,-10z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M11,1h2v3h-2z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M11,20h2v3h-2z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M1,11h3v2H1z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M20,11h3v2h-3z" />
+    <group
+        android:pivotX="12"
+        android:pivotY="12"
+        android:rotation="45">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M11,1h2v3h-2z" />
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M11,20h2v3h-2z" />
+    </group>
+    <group
+        android:pivotX="12"
+        android:pivotY="12"
+        android:rotation="-45">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M11,1h2v3h-2z" />
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M11,20h2v3h-2z" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/side_nav_bar.xml
+++ b/app/src/main/res/drawable/side_nav_bar.xml
@@ -2,8 +2,8 @@
     android:shape="rectangle">
     <gradient
         android:angle="135"
-        android:centerColor="#009688"
-        android:endColor="#00695C"
-        android:startColor="#4DB6AC"
+        android:centerColor="@color/primary_red"
+        android:endColor="@color/primary_red_variant"
+        android:startColor="@color/primary_red_light"
         android:type="linear" />
 </shape>

--- a/app/src/main/res/layout/app_bar_main.xml
+++ b/app/src/main/res/layout/app_bar_main.xml
@@ -29,6 +29,7 @@
         android:layout_gravity="bottom|end"
         android:layout_marginEnd="@dimen/fab_margin"
         android:layout_marginBottom="16dp"
-        app:srcCompat="@android:drawable/ic_dialog_email" />
+        android:contentDescription="@string/toggle_theme"
+        app:srcCompat="@drawable/ic_moon" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -2,13 +2,15 @@
     <!-- Base application theme. -->
     <style name="Theme.FeelOScope" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_200</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
-        <item name="colorOnPrimary">@color/black</item>
+        <item name="colorPrimary">@color/primary_red</item>
+        <item name="colorPrimaryVariant">@color/primary_red_variant</item>
+        <item name="colorOnPrimary">@color/off_white</item>
         <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_200</item>
-        <item name="colorOnSecondary">@color/black</item>
+        <item name="colorSecondary">@color/primary_red</item>
+        <item name="colorSecondaryVariant">@color/primary_red_variant</item>
+        <item name="colorOnSecondary">@color/off_white</item>
+        <item name="android:colorBackground">@color/dark_gray</item>
+        <item name="android:navigationBarColor">@color/dark_gray</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="purple_200">#FFBB86FC</color>
-    <color name="purple_500">#FF6200EE</color>
-    <color name="purple_700">#FF3700B3</color>
-    <color name="teal_200">#FF03DAC5</color>
-    <color name="teal_700">#FF018786</color>
+    <color name="primary_red">#FFC62325</color>
+    <color name="primary_red_variant">#FF8F191B</color>
+    <color name="primary_red_light">#FFE1585A</color>
     <color name="black">#FF000000</color>
+    <color name="dark_gray">#FF222222</color>
+    <color name="off_white">#FFF5F5F5</color>
     <color name="white">#FFFFFFFF</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="nav_header_subtitle">android.studio@android.com</string>
     <string name="nav_header_desc">Navigation header</string>
     <string name="action_settings">Settings</string>
+    <string name="toggle_theme">Toggle dark mode</string>
 
     <string name="menu_home">Home</string>
     <string name="menu_gallery">Gallery</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,13 +2,15 @@
     <!-- Base application theme. -->
     <style name="Theme.FeelOScope" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_500</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
+        <item name="colorPrimary">@color/primary_red</item>
+        <item name="colorPrimaryVariant">@color/primary_red_variant</item>
         <item name="colorOnPrimary">@color/white</item>
         <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_700</item>
-        <item name="colorOnSecondary">@color/black</item>
+        <item name="colorSecondary">@color/primary_red</item>
+        <item name="colorSecondaryVariant">@color/primary_red_variant</item>
+        <item name="colorOnSecondary">@color/white</item>
+        <item name="android:colorBackground">@color/off_white</item>
+        <item name="android:navigationBarColor">@color/off_white</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->


### PR DESCRIPTION
## Summary
- update the Material theme to use the new red, gray, and off-white palette across light and dark modes
- restyle the navigation header gradient and resources to match the refreshed colors
- replace the email FAB with a dark-mode toggle button and add sun/moon vector icons

## Testing
- `./gradlew lint` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da50890fe083308df11fa3dc687e9c