### PR TITLE
Adjust app bar toolbar layout

### DIFF
--- a/app/src/main/res/layout/app_bar_main.xml
+++ b/app/src/main/res/layout/app_bar_main.xml
@@ -20,7 +20,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
                 android:background="?attr/colorPrimary"
-                android:paddingEnd="72dp"
                 android:clipToPadding="false"
                 app:popupTheme="@style/Theme.FeelOScope.PopupOverlay" />
 
@@ -28,8 +27,7 @@
                 android:id="@+id/imageView_ohm_logo"
                 android:layout_width="48dp"
                 android:layout_height="48dp"
-                android:layout_gravity="end|center_vertical"
-                android:layout_marginEnd="8dp"
+                android:layout_gravity="center"
                 android:adjustViewBounds="true"
                 android:contentDescription="@string/ohm_logo_description"
                 android:padding="8dp"


### PR DESCRIPTION
## Summary
- remove manual end padding from the toolbar so menu items align with the edge
- center the overlaid logo within the app bar frame layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da5bbb2e3c8330b37aeb613cbbc155