### PR TITLE
Update navigation labels and resize header logo

### DIFF
--- a/app/src/main/java/com/example/feeloscope/ui/gallery/GalleryViewModel.java
+++ b/app/src/main/java/com/example/feeloscope/ui/gallery/GalleryViewModel.java
@@ -10,7 +10,7 @@ public class GalleryViewModel extends ViewModel {
 
     public GalleryViewModel() {
         mText = new MutableLiveData<>();
-        mText.setValue("This is gallery fragment");
+        mText.setValue("Hier kannst du deine Bilder nutzen");
     }
 
     public LiveData<String> getText() {

--- a/app/src/main/java/com/example/feeloscope/ui/home/HomeViewModel.java
+++ b/app/src/main/java/com/example/feeloscope/ui/home/HomeViewModel.java
@@ -10,7 +10,7 @@ public class HomeViewModel extends ViewModel {
 
     public HomeViewModel() {
         mText = new MutableLiveData<>();
-        mText.setValue("This is home fragment");
+        mText.setValue("Dies ist der Kamera-Bereich");
     }
 
     public LiveData<String> getText() {

--- a/app/src/main/java/com/example/feeloscope/ui/slideshow/SlideshowViewModel.java
+++ b/app/src/main/java/com/example/feeloscope/ui/slideshow/SlideshowViewModel.java
@@ -10,7 +10,7 @@ public class SlideshowViewModel extends ViewModel {
 
     public SlideshowViewModel() {
         mText = new MutableLiveData<>();
-        mText.setValue("This is slideshow fragment");
+        mText.setValue("Hier kannst du deine Videos nutzen");
     }
 
     public LiveData<String> getText() {

--- a/app/src/main/res/layout/app_bar_main.xml
+++ b/app/src/main/res/layout/app_bar_main.xml
@@ -25,13 +25,11 @@
 
             <ImageView
                 android:id="@+id/imageView_ohm_logo"
-                android:layout_width="48dp"
-                android:layout_height="48dp"
-                android:layout_gravity="center"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:adjustViewBounds="true"
                 android:contentDescription="@string/ohm_logo_description"
-                android:padding="8dp"
-                android:scaleType="centerInside"
+                android:scaleType="fitCenter"
                 app:srcCompat="@drawable/logo_ohm" />
 
         </FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,8 +8,8 @@
     <string name="action_settings">Settings</string>
     <string name="toggle_theme">Toggle dark mode</string>
 
-    <string name="menu_home">Home</string>
-    <string name="menu_gallery">Gallery</string>
-    <string name="menu_slideshow">Slideshow</string>
+    <string name="menu_home">Kamera</string>
+    <string name="menu_gallery">deine Bilder nutzen</string>
+    <string name="menu_slideshow">deine Videos nutzen</string>
     <string name="ohm_logo_description">Technische Hochschule Nürnberg logo</string>
 </resources>


### PR DESCRIPTION
## Summary
- rename navigation labels to Kamera, deine Bilder nutzen, and deine Videos nutzen to reflect the updated sections
- adjust header logo image view to scale the new logo across the app bar
- refresh fragment placeholder copy to match the renamed destinations

## Testing
- ./gradlew test *(fails: requires local Android SDK configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68da5d2e7a7c83309a86fb0ee8e880d0