### PR TITLE
Add ML Kit face detection dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation(libs.camera.camera2)
     implementation(libs.camera.lifecycle)
     implementation(libs.camera.view)
+    implementation(libs.mlkit.face.detection)
     testImplementation(libs.junit)
     androidTestImplementation(libs.ext.junit)
     androidTestImplementation(libs.espresso.core)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ lifecycleViewmodelKtx = "2.9.4"
 navigationFragment = "2.6.0"
 navigationUi = "2.6.0"
 cameraX = "1.3.4"
+mlkitFaceDetection = "16.1.6"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -26,6 +27,7 @@ navigation-ui = { group = "androidx.navigation", name = "navigation-ui", version
 camera-camera2 = { group = "androidx.camera", name = "camera-camera2", version.ref = "cameraX" }
 camera-lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "cameraX" }
 camera-view = { group = "androidx.camera", name = "camera-view", version.ref = "cameraX" }
+mlkit-face-detection = { group = "com.google.mlkit", name = "face-detection", version.ref = "mlkitFaceDetection" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add the ML Kit face detection dependency to the version catalog
- wire the new library into the app module to satisfy FaceDetectionHelper imports

## Testing
- not run (Android SDK not available in CI environment)

------
https://chatgpt.com/codex/tasks/task_e_68da7e4094308330a766ce8d8345ccbe