### PR TITLE
Fix resource linking error from shape overlay style

### DIFF
--- a/app/src/main/res/layout/fragment_gallery.xml
+++ b/app/src/main/res/layout/fragment_gallery.xml
@@ -130,7 +130,7 @@
                     android:layout_marginEnd="16dp"
                     android:contentDescription="@string/gallery_preview_content_description"
                     android:scaleType="centerCrop"
-                    app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.MaterialComponents.Circle"
+                    app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.FeelOScope.Circle"
                     app:srcCompat="@drawable/ic_menu_gallery"
                     app:strokeColor="@color/brand_surface_stroke"
                     app:strokeWidth="1dp" />

--- a/app/src/main/res/layout/fragment_slideshow.xml
+++ b/app/src/main/res/layout/fragment_slideshow.xml
@@ -130,7 +130,7 @@
                     android:layout_marginEnd="16dp"
                     android:contentDescription="@string/slideshow_preview_content_description"
                     android:scaleType="centerCrop"
-                    app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.MaterialComponents.Circle"
+                    app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.FeelOScope.Circle"
                     app:srcCompat="@drawable/ic_menu_slideshow"
                     app:strokeColor="@color/brand_surface_stroke"
                     app:strokeWidth="1dp" />

--- a/app/src/main/res/layout/nav_header_main.xml
+++ b/app/src/main/res/layout/nav_header_main.xml
@@ -29,7 +29,7 @@
                 android:contentDescription="@string/nav_header_desc"
                 android:scaleType="centerCrop"
                 app:srcCompat="@drawable/logo_ohm"
-                app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.MaterialComponents.Circle"
+                app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.FeelOScope.Circle"
                 app:strokeColor="@color/brand_surface_stroke"
                 app:strokeWidth="1dp" />
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -10,7 +10,7 @@
         <item name="chipEndPadding">12dp</item>
     </style>
 
-    <style name="ShapeAppearanceOverlay.MaterialComponents.Circle">
+    <style name="ShapeAppearanceOverlay.FeelOScope.Circle">
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">50%</item>
     </style>


### PR DESCRIPTION
## Summary
- rename the custom circle shape overlay to use a project-specific namespace so it no longer depends on a missing MaterialComponents base style
- update every ShapeableImageView reference to the new overlay style

## Testing
- ./gradlew :app:assembleDebug *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da7d83f3c48330a7fe8b304a41f071