### PR TITLE
Fix missing parent style for circle overlay

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -10,7 +10,7 @@
         <item name="chipEndPadding">12dp</item>
     </style>
 
-    <style name="ShapeAppearanceOverlay.FeelOScope.Circle">
+    <style name="ShapeAppearanceOverlay.FeelOScope.Circle" parent="@style/ShapeAppearanceOverlay.MaterialComponents.SmallComponent">
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">50%</item>
     </style>


### PR DESCRIPTION
## Summary
- set an explicit Material Components parent for the ShapeAppearanceOverlay.FeelOScope.Circle style to avoid missing resource errors during resource linking

## Testing
- ./gradlew :app:processDebugResources *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da81a7a8748330a98835b652ea256a