### PR TITLE
Fix shape appearance overlay resource reference

### DIFF
--- a/app/src/main/res/layout/fragment_gallery.xml
+++ b/app/src/main/res/layout/fragment_gallery.xml
@@ -130,7 +130,7 @@
                     android:layout_marginEnd="16dp"
                     android:contentDescription="@string/gallery_preview_content_description"
                     android:scaleType="centerCrop"
-                    app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.FeelOScope.Circle"
+                    app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.FeelOScope"
                     app:srcCompat="@drawable/ic_menu_gallery"
                     app:strokeColor="@color/brand_surface_stroke"
                     app:strokeWidth="1dp" />

--- a/app/src/main/res/layout/fragment_slideshow.xml
+++ b/app/src/main/res/layout/fragment_slideshow.xml
@@ -130,7 +130,7 @@
                     android:layout_marginEnd="16dp"
                     android:contentDescription="@string/slideshow_preview_content_description"
                     android:scaleType="centerCrop"
-                    app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.FeelOScope.Circle"
+                    app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.FeelOScope"
                     app:srcCompat="@drawable/ic_menu_slideshow"
                     app:strokeColor="@color/brand_surface_stroke"
                     app:strokeWidth="1dp" />

--- a/app/src/main/res/layout/nav_header_main.xml
+++ b/app/src/main/res/layout/nav_header_main.xml
@@ -29,7 +29,7 @@
                 android:contentDescription="@string/nav_header_desc"
                 android:scaleType="centerCrop"
                 app:srcCompat="@drawable/logo_ohm"
-                app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.FeelOScope.Circle"
+                app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.FeelOScope"
                 app:strokeColor="@color/brand_surface_stroke"
                 app:strokeWidth="1dp" />
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -10,7 +10,7 @@
         <item name="chipEndPadding">12dp</item>
     </style>
 
-    <style name="ShapeAppearanceOverlay.FeelOScope.Circle" parent="@style/ShapeAppearanceOverlay.MaterialComponents.SmallComponent">
+    <style name="ShapeAppearanceOverlay.FeelOScope" parent="@style/ShapeAppearanceOverlay.MaterialComponents.SmallComponent">
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">50%</item>
     </style>


### PR DESCRIPTION
## Summary
- rename the custom ShapeAppearance overlay style so it resolves during resource linking
- update gallery, slideshow, and navigation header layouts to use the renamed overlay

## Testing
- ./gradlew assembleDebug *(fails: SDK location not found in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68da8395de788330929562e18dc63405