### PR TITLE
Fix chip shape overlay style parent

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -10,7 +10,7 @@
         <item name="chipEndPadding">12dp</item>
     </style>
 
-    <style name="ShapeAppearanceOverlay.FeelOScope" parent="@style/ShapeAppearanceOverlay.MaterialComponents.SmallComponent">
+    <style name="ShapeAppearanceOverlay.FeelOScope">
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">50%</item>
     </style>


### PR DESCRIPTION
## Summary
- remove the dependency on ShapeAppearanceOverlay.MaterialComponents.SmallComponent for the custom chip overlay style to avoid missing resource errors

## Testing
- ./gradlew :app:processDebugResources *(fails: Android SDK is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da85463c6c8330b879427d9f3cdc96