### PR TITLE
Fix chip layout parameters in home fragment

### DIFF
--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -113,6 +113,8 @@
                 <com.google.android.material.chip.Chip
                     android:id="@+id/chip_live_mode"
                     style="@style/Widget.MaterialComponents.Chip.Filter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
                     android:layout_marginEnd="8dp"
                     android:text="@string/home_chip_live"
                     android:textColor="@color/text_secondary_on_dark"
@@ -125,6 +127,8 @@
                 <com.google.android.material.chip.Chip
                     android:id="@+id/chip_guided"
                     style="@style/Widget.MaterialComponents.Chip.Filter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
                     android:text="@string/home_chip_guided"
                     android:textColor="@color/text_secondary_on_dark"
                     app:chipBackgroundColor="@color/chip_background_tint"


### PR DESCRIPTION
## Summary
- add explicit layout width and height attributes to the home screen chips to satisfy ChipGroup layout requirements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da87b24a4c8330b594945cda941b77