### PR TITLE
Fix NavigationView header chip layout parameters

### DIFF
--- a/app/src/main/res/layout/nav_header_main.xml
+++ b/app/src/main/res/layout/nav_header_main.xml
@@ -62,14 +62,16 @@
                 android:textColor="@color/text_secondary_on_dark"
                 android:textSize="14sp" />
 
-            <com.google.android.material.chip.Chip
-                android:id="@+id/nav_header_status_chip"
-                style="@style/Widget.MaterialComponents.Chip.Assist"
-                android:layout_marginTop="16dp"
-                android:text="@string/nav_header_status"
-                android:textColor="@color/text_secondary_on_dark"
-                app:chipBackgroundColor="@color/chip_background_tint"
-                app:chipIcon="@drawable/ic_menu_camera"
+        <com.google.android.material.chip.Chip
+            android:id="@+id/nav_header_status_chip"
+            style="@style/Widget.MaterialComponents.Chip.Assist"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/nav_header_status"
+            android:textColor="@color/text_secondary_on_dark"
+            app:chipBackgroundColor="@color/chip_background_tint"
+            app:chipIcon="@drawable/ic_menu_camera"
                 app:chipIconTint="@color/text_secondary_on_dark" />
         </LinearLayout>
     </com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
## Summary
- add explicit layout width and height to the navigation drawer header chip to satisfy Material requirements and prevent inflation crashes

## Testing
- ./gradlew lintDebug *(fails: Android SDK is unavailable in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da88c94a3083309d1b812cbc75ba67