### PR TITLE
Enable gallery and video AI analysis from the sidebar

### DIFF
--- a/app/src/main/java/com/example/feeloscope/ui/gallery/GalleryFragment.java
+++ b/app/src/main/java/com/example/feeloscope/ui/gallery/GalleryFragment.java
@@ -1,37 +1,124 @@
 package com.example.feeloscope.ui.gallery;
 
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.TextView;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-import androidx.lifecycle.ViewModelProvider;
 
+import com.example.feeloscope.R;
 import com.example.feeloscope.databinding.FragmentGalleryBinding;
+import com.example.feeloscope.services.FaceDetectionHelper;
+import com.example.feeloscope.services.FaceDetectionListener;
+import com.google.mlkit.vision.common.InputImage;
+import com.google.mlkit.vision.face.Face;
+
+import java.io.IOException;
+import java.util.List;
 
 public class GalleryFragment extends Fragment {
 
     private FragmentGalleryBinding binding;
+    private ActivityResultLauncher<String[]> imagePickerLauncher;
+    private FaceDetectionHelper faceDetectionHelper;
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        faceDetectionHelper = new FaceDetectionHelper(new FaceDetectionListener() {
+            @Override
+            public void onFacesDetected(List<Face> faces, InputImage image) {
+                if (!isAdded() || binding == null) {
+                    return;
+                }
+                int count = faces.size();
+                String message;
+                if (count == 0) {
+                    message = getString(R.string.gallery_analysis_result_none);
+                } else if (count == 1) {
+                    message = getString(R.string.gallery_analysis_result_single);
+                } else {
+                    message = getString(R.string.gallery_analysis_result_multiple, count);
+                }
+                binding.analysisResult.setText(message);
+            }
+
+            @Override
+            public void onError(Exception e) {
+                if (!isAdded() || binding == null) {
+                    return;
+                }
+                String message = TextUtils.isEmpty(e.getLocalizedMessage())
+                        ? e.getClass().getSimpleName()
+                        : e.getLocalizedMessage();
+                binding.analysisResult.setText(getString(R.string.gallery_analysis_error, message));
+            }
+        });
+
+        imagePickerLauncher = registerForActivityResult(new ActivityResultContracts.OpenDocument(), this::handleImageResult);
+    }
 
     public View onCreateView(@NonNull LayoutInflater inflater,
                              ViewGroup container, Bundle savedInstanceState) {
-        GalleryViewModel galleryViewModel =
-                new ViewModelProvider(this).get(GalleryViewModel.class);
-
         binding = FragmentGalleryBinding.inflate(inflater, container, false);
-        View root = binding.getRoot();
+        binding.selectImageButton.setOnClickListener(v -> imagePickerLauncher.launch(new String[]{"image/*"}));
+        return binding.getRoot();
+    }
 
-        final TextView textView = binding.textGallery;
-        galleryViewModel.getText().observe(getViewLifecycleOwner(), textView::setText);
-        return root;
+    private void handleImageResult(@Nullable Uri uri) {
+        if (!isAdded() || binding == null || uri == null) {
+            return;
+        }
+
+        binding.analysisResult.setText(getString(R.string.gallery_analysis_in_progress));
+        binding.selectedImage.setVisibility(View.VISIBLE);
+        binding.selectedImage.setImageURI(uri);
+
+        try {
+            requireContext().getContentResolver().takePersistableUriPermission(
+                    uri,
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION
+            );
+        } catch (SecurityException ignored) {
+            // If the URI does not support persistable permissions we can still use it for this session.
+        }
+
+        analyzeImage(uri);
+    }
+
+    private void analyzeImage(@NonNull Uri uri) {
+        if (!isAdded()) {
+            return;
+        }
+        try {
+            InputImage inputImage = InputImage.fromFilePath(requireContext(), uri);
+            faceDetectionHelper.process(inputImage);
+        } catch (IOException e) {
+            if (binding != null) {
+                binding.analysisResult.setText(getString(R.string.gallery_analysis_error, e.getLocalizedMessage()));
+            }
+        }
     }
 
     @Override
     public void onDestroyView() {
         super.onDestroyView();
         binding = null;
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        if (faceDetectionHelper != null) {
+            faceDetectionHelper.close();
+        }
     }
 }

--- a/app/src/main/java/com/example/feeloscope/ui/slideshow/SlideshowFragment.java
+++ b/app/src/main/java/com/example/feeloscope/ui/slideshow/SlideshowFragment.java
@@ -1,37 +1,149 @@
 package com.example.feeloscope.ui.slideshow;
 
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.media.MediaMetadataRetriever;
+import android.net.Uri;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.TextView;
+import android.widget.MediaController;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-import androidx.lifecycle.ViewModelProvider;
 
+import com.example.feeloscope.R;
 import com.example.feeloscope.databinding.FragmentSlideshowBinding;
+import com.example.feeloscope.services.FaceDetectionHelper;
+import com.example.feeloscope.services.FaceDetectionListener;
+import com.google.mlkit.vision.common.InputImage;
+import com.google.mlkit.vision.face.Face;
+
+import java.util.List;
 
 public class SlideshowFragment extends Fragment {
 
     private FragmentSlideshowBinding binding;
+    private ActivityResultLauncher<String[]> videoPickerLauncher;
+    private FaceDetectionHelper faceDetectionHelper;
+    private MediaController mediaController;
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        faceDetectionHelper = new FaceDetectionHelper(new FaceDetectionListener() {
+            @Override
+            public void onFacesDetected(List<Face> faces, InputImage image) {
+                if (!isAdded() || binding == null) {
+                    return;
+                }
+                String faceSummary;
+                int count = faces.size();
+                if (count == 0) {
+                    faceSummary = getString(R.string.gallery_analysis_result_none);
+                } else if (count == 1) {
+                    faceSummary = getString(R.string.gallery_analysis_result_single);
+                } else {
+                    faceSummary = getString(R.string.gallery_analysis_result_multiple, count);
+                }
+                binding.videoAnalysisResult.setText(getString(R.string.video_analysis_result_template, faceSummary));
+            }
+
+            @Override
+            public void onError(Exception e) {
+                if (!isAdded() || binding == null) {
+                    return;
+                }
+                String message = TextUtils.isEmpty(e.getLocalizedMessage())
+                        ? e.getClass().getSimpleName()
+                        : e.getLocalizedMessage();
+                binding.videoAnalysisResult.setText(getString(R.string.gallery_analysis_error, message));
+            }
+        });
+
+        videoPickerLauncher = registerForActivityResult(new ActivityResultContracts.OpenDocument(), this::handleVideoResult);
+    }
 
     public View onCreateView(@NonNull LayoutInflater inflater,
                              ViewGroup container, Bundle savedInstanceState) {
-        SlideshowViewModel slideshowViewModel =
-                new ViewModelProvider(this).get(SlideshowViewModel.class);
-
         binding = FragmentSlideshowBinding.inflate(inflater, container, false);
-        View root = binding.getRoot();
+        binding.selectVideoButton.setOnClickListener(v -> videoPickerLauncher.launch(new String[]{"video/*"}));
+        return binding.getRoot();
+    }
 
-        final TextView textView = binding.textSlideshow;
-        slideshowViewModel.getText().observe(getViewLifecycleOwner(), textView::setText);
-        return root;
+    private void handleVideoResult(@Nullable Uri uri) {
+        if (!isAdded() || binding == null || uri == null) {
+            return;
+        }
+
+        binding.videoAnalysisResult.setText(getString(R.string.gallery_analysis_in_progress));
+        binding.selectedVideo.setVisibility(View.VISIBLE);
+        binding.selectedVideo.setVideoURI(uri);
+
+        if (mediaController == null) {
+            mediaController = new MediaController(requireContext());
+        }
+        mediaController.setAnchorView(binding.selectedVideo);
+        binding.selectedVideo.setMediaController(mediaController);
+        binding.selectedVideo.setOnPreparedListener(mp -> {
+            mp.setLooping(true);
+            binding.selectedVideo.start();
+        });
+        binding.selectedVideo.seekTo(1);
+
+        try {
+            requireContext().getContentResolver().takePersistableUriPermission(
+                    uri,
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION
+            );
+        } catch (SecurityException ignored) {
+            // Ignore when persistable permissions are not supported.
+        }
+
+        analyzeVideo(uri);
+    }
+
+    private void analyzeVideo(@NonNull Uri uri) {
+        MediaMetadataRetriever retriever = new MediaMetadataRetriever();
+        try {
+            retriever.setDataSource(requireContext(), uri);
+            Bitmap frame = retriever.getFrameAtTime(0);
+            if (frame == null) {
+                if (binding != null) {
+                    binding.videoAnalysisResult.setText(R.string.video_analysis_frame_missing);
+                }
+                return;
+            }
+            InputImage image = InputImage.fromBitmap(frame, 0);
+            faceDetectionHelper.process(image);
+        } catch (RuntimeException e) {
+            if (binding != null) {
+                binding.videoAnalysisResult.setText(getString(R.string.gallery_analysis_error, e.getLocalizedMessage()));
+            }
+        } finally {
+            retriever.release();
+        }
     }
 
     @Override
     public void onDestroyView() {
         super.onDestroyView();
+        if (binding != null) {
+            binding.selectedVideo.stopPlayback();
+        }
         binding = null;
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        if (faceDetectionHelper != null) {
+            faceDetectionHelper.close();
+        }
     }
 }

--- a/app/src/main/res/layout/fragment_gallery.xml
+++ b/app/src/main/res/layout/fragment_gallery.xml
@@ -1,22 +1,122 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fillViewport="true"
+    android:padding="16dp"
     tools:context=".ui.gallery.GalleryFragment">
 
-    <TextView
-        android:id="@+id/text_gallery"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
-        android:textAlignment="center"
-        android:textSize="20sp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        android:paddingBottom="32dp">
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/galleryCard"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="24dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="16dp"
+            android:foregroundGravity="center"
+            app:cardBackgroundColor="@color/overlay_card_background"
+            app:cardCornerRadius="20dp"
+            app:cardElevation="2dp"
+            app:cardUseCompatPadding="true"
+            app:strokeColor="@color/overlay_card_stroke"
+            app:strokeWidth="1dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="20dp">
+
+                <TextView
+                    android:id="@+id/galleryInstruction"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:autoSizeMaxTextSize="22sp"
+                    app:autoSizeMinTextSize="14sp"
+                    app:autoSizeStepGranularity="2sp"
+                    app:autoSizeTextType="uniform"
+                    android:text="@string/gallery_instruction"
+                    android:textColor="@android:color/white"
+                    android:textStyle="bold" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/selectImageButton"
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:text="@string/gallery_select_button"
+                    app:icon="@drawable/ic_menu_gallery"
+                    app:iconGravity="textStart"
+                    app:iconPadding="8dp"
+                    app:iconTint="@android:color/white" />
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <ImageView
+            android:id="@+id/selectedImage"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="32dp"
+            android:adjustViewBounds="true"
+            android:contentDescription="@string/gallery_selected_image_content_description"
+            android:scaleType="fitCenter"
+            android:visibility="gone" />
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/analysisCard"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="24dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="32dp"
+            app:cardBackgroundColor="@color/overlay_card_background"
+            app:cardCornerRadius="20dp"
+            app:cardElevation="2dp"
+            app:cardUseCompatPadding="true"
+            app:strokeColor="@color/overlay_card_stroke"
+            app:strokeWidth="1dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="20dp">
+
+                <TextView
+                    android:id="@+id/analysisTitle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:autoSizeMaxTextSize="20sp"
+                    app:autoSizeMinTextSize="12sp"
+                    app:autoSizeStepGranularity="2sp"
+                    app:autoSizeTextType="uniform"
+                    android:text="@string/gallery_analysis_title"
+                    android:textColor="@android:color/white"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/analysisResult"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    app:autoSizeMaxTextSize="18sp"
+                    app:autoSizeMinTextSize="12sp"
+                    app:autoSizeStepGranularity="2sp"
+                    app:autoSizeTextType="uniform"
+                    android:text="@string/gallery_analysis_placeholder"
+                    android:textColor="@android:color/white" />
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+    </LinearLayout>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_slideshow.xml
+++ b/app/src/main/res/layout/fragment_slideshow.xml
@@ -1,22 +1,119 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fillViewport="true"
+    android:padding="16dp"
     tools:context=".ui.slideshow.SlideshowFragment">
 
-    <TextView
-        android:id="@+id/text_slideshow"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
-        android:textAlignment="center"
-        android:textSize="20sp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        android:paddingBottom="32dp">
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/videoCard"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="24dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="16dp"
+            app:cardBackgroundColor="@color/overlay_card_background"
+            app:cardCornerRadius="20dp"
+            app:cardElevation="2dp"
+            app:cardUseCompatPadding="true"
+            app:strokeColor="@color/overlay_card_stroke"
+            app:strokeWidth="1dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="20dp">
+
+                <TextView
+                    android:id="@+id/videoInstruction"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:autoSizeMaxTextSize="22sp"
+                    app:autoSizeMinTextSize="14sp"
+                    app:autoSizeStepGranularity="2sp"
+                    app:autoSizeTextType="uniform"
+                    android:text="@string/video_instruction"
+                    android:textColor="@android:color/white"
+                    android:textStyle="bold" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/selectVideoButton"
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:text="@string/video_select_button"
+                    app:icon="@drawable/ic_menu_slideshow"
+                    app:iconGravity="textStart"
+                    app:iconPadding="8dp"
+                    app:iconTint="@android:color/white" />
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <VideoView
+            android:id="@+id/selectedVideo"
+            android:layout_width="match_parent"
+            android:layout_height="200dp"
+            android:layout_marginHorizontal="32dp"
+            android:contentDescription="@string/video_selected_content_description"
+            android:visibility="gone" />
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/videoAnalysisCard"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="24dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="32dp"
+            app:cardBackgroundColor="@color/overlay_card_background"
+            app:cardCornerRadius="20dp"
+            app:cardElevation="2dp"
+            app:cardUseCompatPadding="true"
+            app:strokeColor="@color/overlay_card_stroke"
+            app:strokeWidth="1dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="20dp">
+
+                <TextView
+                    android:id="@+id/videoAnalysisTitle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:autoSizeMaxTextSize="20sp"
+                    app:autoSizeMinTextSize="12sp"
+                    app:autoSizeStepGranularity="2sp"
+                    app:autoSizeTextType="uniform"
+                    android:text="@string/gallery_analysis_title"
+                    android:textColor="@android:color/white"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/videoAnalysisResult"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    app:autoSizeMaxTextSize="18sp"
+                    app:autoSizeMinTextSize="12sp"
+                    app:autoSizeStepGranularity="2sp"
+                    app:autoSizeTextType="uniform"
+                    android:text="@string/video_analysis_placeholder"
+                    android:textColor="@android:color/white" />
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+    </LinearLayout>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,6 @@
     <color name="dark_gray">#FF222222</color>
     <color name="off_white">#FFF5F5F5</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="overlay_card_background">#CC1E1E1E</color>
+    <color name="overlay_card_stroke">#66FFFFFF</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,4 +19,20 @@
     <string name="camera_permission_denied">Kamerazugriff erforderlich, um die Vorschau anzuzeigen.</string>
     <string name="ai_enabled_message">AI-Unterstützung aktiviert.</string>
     <string name="ai_disabled_message">AI-Unterstützung deaktiviert.</string>
+    <string name="gallery_instruction">Wähle ein Bild aus deiner Galerie aus, um es von der AI analysieren zu lassen.</string>
+    <string name="gallery_select_button">Bild auswählen</string>
+    <string name="gallery_selected_image_content_description">Ausgewähltes Bild für die Analyse</string>
+    <string name="gallery_analysis_title">Analyseergebnis</string>
+    <string name="gallery_analysis_placeholder">Noch kein Bild ausgewählt.</string>
+    <string name="gallery_analysis_in_progress">Analyse läuft…</string>
+    <string name="gallery_analysis_result_single">Es wurde ein Gesicht erkannt.</string>
+    <string name="gallery_analysis_result_multiple">Es wurden %1$d Gesichter erkannt.</string>
+    <string name="gallery_analysis_result_none">Es wurden keine Gesichter erkannt.</string>
+    <string name="gallery_analysis_error">Die Analyse konnte nicht durchgeführt werden: %1$s</string>
+    <string name="video_instruction">Wähle ein Video aus deiner Galerie aus. Das erste Videoframe wird zur AI-Analyse verwendet.</string>
+    <string name="video_select_button">Video auswählen</string>
+    <string name="video_analysis_placeholder">Noch kein Video ausgewählt.</string>
+    <string name="video_selected_content_description">Ausgewähltes Video für die Analyse</string>
+    <string name="video_analysis_frame_missing">Das Video konnte nicht analysiert werden. Versuche ein anderes Video.</string>
+    <string name="video_analysis_result_template">Analyse des ersten Frames: %1$s</string>
 </resources>


### PR DESCRIPTION
## Summary
- add an image picker flow that shows the chosen photo and runs the existing ML Kit face analysis on it
- add a video picker that plays the selected clip and analyses its first frame with the same AI helper
- refresh the gallery and video screens with compact, translucent cards, padded copy, and responsive typography

## Testing
- `./gradlew test` *(fails: Android SDK not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68da8f03fa9483308ef8026649eecdc4