### PR TITLE
Handle IOException when releasing MediaMetadataRetriever

### DIFF
--- a/app/src/main/java/com/example/feeloscope/ui/slideshow/SlideshowFragment.java
+++ b/app/src/main/java/com/example/feeloscope/ui/slideshow/SlideshowFragment.java
@@ -24,6 +24,7 @@ import com.example.feeloscope.services.FaceDetectionListener;
 import com.google.mlkit.vision.common.InputImage;
 import com.google.mlkit.vision.face.Face;
 
+import java.io.IOException;
 import java.util.List;
 
 public class SlideshowFragment extends Fragment {
@@ -126,7 +127,16 @@ public class SlideshowFragment extends Fragment {
                 binding.videoAnalysisResult.setText(getString(R.string.gallery_analysis_error, e.getLocalizedMessage()));
             }
         } finally {
-            retriever.release();
+            try {
+                retriever.release();
+            } catch (IOException e) {
+                if (binding != null) {
+                    String message = TextUtils.isEmpty(e.getLocalizedMessage())
+                            ? e.getClass().getSimpleName()
+                            : e.getLocalizedMessage();
+                    binding.videoAnalysisResult.setText(getString(R.string.gallery_analysis_error, message));
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- handle the checked IOException thrown by `MediaMetadataRetriever.release()`
- surface a user-facing error message if releasing the retriever fails

## Testing
- `./gradlew compileDebugJavaWithJavac` *(fails: SDK not installed in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68da9168b31883308c61a90004a7c2a5