### PR TITLE
Adjust card sizing and spacing

### DIFF
--- a/app/src/main/res/layout/fragment_gallery.xml
+++ b/app/src/main/res/layout/fragment_gallery.xml
@@ -20,8 +20,10 @@
         <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginEnd="12dp"
             android:layout_marginBottom="20dp"
-            android:padding="24dp"
+            android:padding="28dp"
             app:cardBackgroundColor="@color/surface_card_background"
             app:cardCornerRadius="28dp"
             app:cardElevation="6dp"
@@ -40,6 +42,10 @@
                     android:textAlignment="textStart"
                     android:textColor="@color/surface_card_text_primary"
                     android:textSize="22sp"
+                    android:autoSizeTextType="uniform"
+                    android:autoSizeMaxTextSize="22sp"
+                    android:autoSizeMinTextSize="18sp"
+                    android:autoSizeStepGranularity="1sp"
                     android:textStyle="bold"
                     tools:text="Hier kannst du deine Bilder nutzen" />
 
@@ -50,7 +56,11 @@
                     android:layout_marginTop="12dp"
                     android:text="@string/gallery_description"
                     android:textColor="@color/surface_card_text_secondary"
-                    android:textSize="15sp" />
+                    android:textSize="15sp"
+                    android:autoSizeTextType="uniform"
+                    android:autoSizeMaxTextSize="15sp"
+                    android:autoSizeMinTextSize="12sp"
+                    android:autoSizeStepGranularity="1sp" />
 
                 <com.google.android.material.chip.ChipGroup
                     android:id="@+id/gallery_chip_group"
@@ -110,7 +120,9 @@
         <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:padding="24dp"
+            android:layout_marginStart="12dp"
+            android:layout_marginEnd="12dp"
+            android:padding="28dp"
             app:cardBackgroundColor="@color/surface_card_background"
             app:cardCornerRadius="28dp"
             app:cardElevation="0dp"
@@ -148,6 +160,10 @@
                         android:text="@string/gallery_tip_title"
                         android:textColor="@color/surface_card_text_primary"
                         android:textSize="18sp"
+                        android:autoSizeTextType="uniform"
+                        android:autoSizeMaxTextSize="18sp"
+                        android:autoSizeMinTextSize="16sp"
+                        android:autoSizeStepGranularity="1sp"
                         android:textStyle="bold" />
 
                     <TextView
@@ -157,7 +173,11 @@
                         android:layout_marginTop="6dp"
                         android:text="@string/gallery_tip_body"
                         android:textColor="@color/surface_card_text_secondary"
-                        android:textSize="14sp" />
+                        android:textSize="14sp"
+                        android:autoSizeTextType="uniform"
+                        android:autoSizeMaxTextSize="14sp"
+                        android:autoSizeMinTextSize="12sp"
+                        android:autoSizeStepGranularity="1sp" />
 
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/gallery_secondary_button"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -33,16 +33,18 @@
         android:id="@+id/top_info_card"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="24dp"
+        android:layout_marginStart="0dp"
         android:layout_marginTop="36dp"
-        android:layout_marginEnd="24dp"
-        android:padding="20dp"
+        android:layout_marginEnd="0dp"
+        android:padding="24dp"
         app:cardBackgroundColor="@color/surface_card_background"
         app:cardCornerRadius="26dp"
         app:cardElevation="0dp"
+        app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintWidth_percent="0.88"
         app:strokeColor="@color/surface_card_stroke"
         app:strokeWidth="1dp">
 
@@ -57,6 +59,10 @@
                 android:text="@string/home_title"
                 android:textColor="@color/surface_card_text_primary"
                 android:textSize="22sp"
+                android:autoSizeTextType="uniform"
+                android:autoSizeMaxTextSize="22sp"
+                android:autoSizeMinTextSize="18sp"
+                android:autoSizeStepGranularity="1sp"
                 android:textStyle="bold"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
@@ -70,6 +76,10 @@
                 android:text="@string/home_tagline"
                 android:textColor="@color/surface_card_text_secondary"
                 android:textSize="15sp"
+                android:autoSizeTextType="uniform"
+                android:autoSizeMaxTextSize="15sp"
+                android:autoSizeMinTextSize="12sp"
+                android:autoSizeStepGranularity="1sp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/home_title" />
@@ -82,6 +92,10 @@
                 android:text="@string/home_toggle_hint"
                 android:textColor="@color/surface_card_text_secondary"
                 android:textSize="14sp"
+                android:autoSizeTextType="uniform"
+                android:autoSizeMaxTextSize="14sp"
+                android:autoSizeMinTextSize="12sp"
+                android:autoSizeStepGranularity="1sp"
                 app:layout_constraintEnd_toStartOf="@id/ai_toggle_switch"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/home_subtitle" />
@@ -144,16 +158,18 @@
         android:id="@+id/bottom_controls"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="24dp"
-        android:layout_marginEnd="24dp"
+        android:layout_marginStart="0dp"
+        android:layout_marginEnd="0dp"
         android:layout_marginBottom="32dp"
         android:padding="24dp"
         app:cardBackgroundColor="@color/surface_card_background"
         app:cardCornerRadius="32dp"
         app:cardElevation="0dp"
+        app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintWidth_percent="0.9"
         app:strokeColor="@color/surface_card_stroke"
         app:strokeWidth="1dp">
 
@@ -170,6 +186,10 @@
                 android:text="@string/home_shutter_title"
                 android:textColor="@color/surface_card_text_primary"
                 android:textSize="18sp"
+                android:autoSizeTextType="uniform"
+                android:autoSizeMaxTextSize="18sp"
+                android:autoSizeMinTextSize="16sp"
+                android:autoSizeStepGranularity="1sp"
                 android:textStyle="bold" />
 
             <TextView
@@ -180,7 +200,11 @@
                 android:gravity="center"
                 android:text="@string/home_shutter_hint"
                 android:textColor="@color/surface_card_text_secondary"
-                android:textSize="14sp" />
+                android:textSize="14sp"
+                android:autoSizeTextType="uniform"
+                android:autoSizeMaxTextSize="14sp"
+                android:autoSizeMinTextSize="12sp"
+                android:autoSizeStepGranularity="1sp" />
 
             <FrameLayout
                 android:id="@+id/shutter_button"

--- a/app/src/main/res/layout/fragment_slideshow.xml
+++ b/app/src/main/res/layout/fragment_slideshow.xml
@@ -20,8 +20,10 @@
         <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginEnd="12dp"
             android:layout_marginBottom="20dp"
-            android:padding="24dp"
+            android:padding="28dp"
             app:cardBackgroundColor="@color/surface_card_background"
             app:cardCornerRadius="28dp"
             app:cardElevation="6dp"
@@ -40,6 +42,10 @@
                     android:textAlignment="textStart"
                     android:textColor="@color/surface_card_text_primary"
                     android:textSize="22sp"
+                    android:autoSizeTextType="uniform"
+                    android:autoSizeMaxTextSize="22sp"
+                    android:autoSizeMinTextSize="18sp"
+                    android:autoSizeStepGranularity="1sp"
                     android:textStyle="bold"
                     tools:text="Hier kannst du deine Videos nutzen" />
 
@@ -50,7 +56,11 @@
                     android:layout_marginTop="12dp"
                     android:text="@string/slideshow_description"
                     android:textColor="@color/surface_card_text_secondary"
-                    android:textSize="15sp" />
+                    android:textSize="15sp"
+                    android:autoSizeTextType="uniform"
+                    android:autoSizeMaxTextSize="15sp"
+                    android:autoSizeMinTextSize="12sp"
+                    android:autoSizeStepGranularity="1sp" />
 
                 <com.google.android.material.chip.ChipGroup
                     android:id="@+id/slideshow_chip_group"
@@ -110,7 +120,9 @@
         <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:padding="24dp"
+            android:layout_marginStart="12dp"
+            android:layout_marginEnd="12dp"
+            android:padding="28dp"
             app:cardBackgroundColor="@color/surface_card_background"
             app:cardCornerRadius="28dp"
             app:cardElevation="0dp"
@@ -148,6 +160,10 @@
                         android:text="@string/slideshow_tip_title"
                         android:textColor="@color/surface_card_text_primary"
                         android:textSize="18sp"
+                        android:autoSizeTextType="uniform"
+                        android:autoSizeMaxTextSize="18sp"
+                        android:autoSizeMinTextSize="16sp"
+                        android:autoSizeStepGranularity="1sp"
                         android:textStyle="bold" />
 
                     <TextView
@@ -157,7 +173,11 @@
                         android:layout_marginTop="6dp"
                         android:text="@string/slideshow_tip_body"
                         android:textColor="@color/surface_card_text_secondary"
-                        android:textSize="14sp" />
+                        android:textSize="14sp"
+                        android:autoSizeTextType="uniform"
+                        android:autoSizeMaxTextSize="14sp"
+                        android:autoSizeMinTextSize="12sp"
+                        android:autoSizeStepGranularity="1sp" />
 
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/slideshow_secondary_button"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -31,7 +31,7 @@
     <color name="divider_tint">#33222222</color>
 
     <!-- Dynamic surface palette -->
-    <color name="surface_card_background">#F2FFFFFF</color>
+    <color name="surface_card_background">#CCFFFFFF</color>
     <color name="surface_card_stroke">#33C62325</color>
     <color name="surface_card_text_primary">#FF121212</color>
     <color name="surface_card_text_secondary">#CC121212</color>


### PR DESCRIPTION
## Summary
- tighten the width of the home overlay cards, increase their padding, and enable autosizing text so content stays legible in smaller, more translucent cards
- add horizontal margins, larger padding, and autosizing text to gallery and slideshow cards for better spacing from card edges
- lighten the shared surface card background color to make cards feel more translucent across the app

## Testing
- ./gradlew lint *(fails: requires local Android SDK path)*

------
https://chatgpt.com/codex/tasks/task_e_68da91483a108330aa5be4578a2bdfe0