### PR TITLE
Modernize camera capture experience

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation(libs.camera.camera2)
     implementation(libs.camera.lifecycle)
     implementation(libs.camera.view)
+    implementation(libs.preference)
     implementation(libs.mlkit.face.detection)
     testImplementation(libs.junit)
     androidTestImplementation(libs.ext.junit)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,11 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.FeelOScope">
         <activity
+            android:name=".settings.SettingsActivity"
+            android:exported="false"
+            android:label="@string/settings_title"
+            android:theme="@style/Theme.FeelOScope" />
+        <activity
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"

--- a/app/src/main/java/com/example/feeloscope/MainActivity.java
+++ b/app/src/main/java/com/example/feeloscope/MainActivity.java
@@ -1,8 +1,10 @@
 package com.example.feeloscope;
 
+import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -14,6 +16,8 @@ import androidx.navigation.ui.AppBarConfiguration;
 import androidx.navigation.ui.NavigationUI;
 
 import com.example.feeloscope.databinding.ActivityMainBinding;
+import com.example.feeloscope.settings.SettingsActivity;
+import com.google.android.material.button.MaterialButton;
 import com.google.android.material.navigation.NavigationView;
 
 public class MainActivity extends AppCompatActivity {
@@ -47,6 +51,14 @@ public class MainActivity extends AppCompatActivity {
         NavController navController = Navigation.findNavController(this, R.id.nav_host_fragment_content_main);
         NavigationUI.setupActionBarWithNavController(this, navController, mAppBarConfiguration);
         NavigationUI.setupWithNavController(navigationView, navController);
+
+        View headerView = navigationView.getHeaderView(0);
+        if (headerView != null) {
+            MaterialButton headerSettings = headerView.findViewById(R.id.header_settings_button);
+            if (headerSettings != null) {
+                headerSettings.setOnClickListener(v -> startActivity(new Intent(this, SettingsActivity.class)));
+            }
+        }
     }
 
     @Override
@@ -54,6 +66,15 @@ public class MainActivity extends AppCompatActivity {
         // Inflate the menu; this adds items to the action bar if it is present.
         getMenuInflater().inflate(R.menu.main, menu);
         return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == R.id.action_settings) {
+            startActivity(new Intent(this, SettingsActivity.class));
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     @Override

--- a/app/src/main/java/com/example/feeloscope/settings/SettingsActivity.java
+++ b/app/src/main/java/com/example/feeloscope/settings/SettingsActivity.java
@@ -1,0 +1,30 @@
+package com.example.feeloscope.settings;
+
+import android.os.Bundle;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.example.feeloscope.R;
+import com.google.android.material.appbar.MaterialToolbar;
+
+public class SettingsActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_settings);
+
+        MaterialToolbar toolbar = findViewById(R.id.settings_toolbar);
+        setSupportActionBar(toolbar);
+        toolbar.setNavigationIcon(R.drawable.ic_arrow_back);
+        toolbar.setNavigationOnClickListener(v -> getOnBackPressedDispatcher().onBackPressed());
+
+        if (savedInstanceState == null) {
+            getSupportFragmentManager()
+                    .beginTransaction()
+                    .replace(R.id.settings_container, new SettingsFragment())
+                    .commit();
+        }
+    }
+}

--- a/app/src/main/java/com/example/feeloscope/settings/SettingsFragment.java
+++ b/app/src/main/java/com/example/feeloscope/settings/SettingsFragment.java
@@ -1,0 +1,58 @@
+package com.example.feeloscope.settings;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+
+import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.SeekBarPreference;
+
+import com.example.feeloscope.R;
+
+public class SettingsFragment extends PreferenceFragmentCompat implements SharedPreferences.OnSharedPreferenceChangeListener {
+
+    private static final String KEY_OVERLAY_OPACITY = "pref_overlay_opacity";
+    private SeekBarPreference overlayPreference;
+
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        setPreferencesFromResource(R.xml.root_preferences, rootKey);
+        overlayPreference = findPreference(KEY_OVERLAY_OPACITY);
+        updateOverlaySummary();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        SharedPreferences preferences = getPreferenceManager().getSharedPreferences();
+        if (preferences != null) {
+            preferences.registerOnSharedPreferenceChangeListener(this);
+        }
+        updateOverlaySummary();
+    }
+
+    @Override
+    public void onPause() {
+        SharedPreferences preferences = getPreferenceManager().getSharedPreferences();
+        if (preferences != null) {
+            preferences.unregisterOnSharedPreferenceChangeListener(this);
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        if (KEY_OVERLAY_OPACITY.equals(key)) {
+            updateOverlaySummary();
+        }
+    }
+
+    private void updateOverlaySummary() {
+        if (overlayPreference == null) {
+            return;
+        }
+        int value = overlayPreference.getValue();
+        String summary = getString(R.string.pref_summary_overlay_opacity) + "\n"
+                + getString(R.string.pref_overlay_opacity_value, value);
+        overlayPreference.setSummary(summary);
+    }
+}

--- a/app/src/main/java/com/example/feeloscope/ui/home/HomeFragment.java
+++ b/app/src/main/java/com/example/feeloscope/ui/home/HomeFragment.java
@@ -1,11 +1,16 @@
 package com.example.feeloscope.ui.home;
 
 import android.Manifest;
+import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.os.Bundle;
 import android.view.LayoutInflater;
+import android.view.Surface;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.CompoundButton;
 import android.widget.Toast;
 
 import androidx.activity.result.ActivityResultLauncher;
@@ -13,22 +18,49 @@ import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.camera.core.CameraSelector;
+import androidx.camera.core.ImageCapture;
+import androidx.camera.core.ImageCaptureException;
 import androidx.camera.core.Preview;
 import androidx.camera.lifecycle.ProcessCameraProvider;
 import androidx.camera.view.PreviewView;
 import androidx.core.content.ContextCompat;
+import androidx.core.graphics.ColorUtils;
 import androidx.fragment.app.Fragment;
+import androidx.preference.PreferenceManager;
 
 import com.example.feeloscope.R;
 import com.example.feeloscope.databinding.FragmentHomeBinding;
 import com.google.common.util.concurrent.ListenableFuture;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 public class HomeFragment extends Fragment {
 
+    private static final String KEY_AI_TOGGLE_DEFAULT = "pref_ai_toggle_default";
+    private static final String KEY_AUTO_AI_AFTER_CAPTURE = "pref_auto_ai_after_capture";
+    private static final String KEY_OVERLAY_OPACITY = "pref_overlay_opacity";
+    private static final int DEFAULT_OVERLAY_OPACITY = 70;
+
     private FragmentHomeBinding binding;
     private ListenableFuture<ProcessCameraProvider> cameraProviderFuture;
+    private SharedPreferences sharedPreferences;
+    private ImageCapture imageCapture;
+    private File lastPhotoFile;
+    private CompoundButton.OnCheckedChangeListener aiSwitchChangeListener;
+    private boolean suppressAiToast;
+
+    private final SharedPreferences.OnSharedPreferenceChangeListener preferenceChangeListener = (prefs, key) -> {
+        if (binding == null) {
+            return;
+        }
+        if (KEY_AI_TOGGLE_DEFAULT.equals(key)) {
+            applyAiDefault();
+        } else if (KEY_OVERLAY_OPACITY.equals(key)) {
+            applyOverlayOpacity();
+        }
+    };
 
     private final ActivityResultLauncher<String> requestPermissionLauncher =
             registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
@@ -50,23 +82,41 @@ public class HomeFragment extends Fragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        binding.shutterButton.setOnClickListener(v -> {
-            if (isAdded()) {
-                Toast.makeText(requireContext(), R.string.shutter_placeholder_message, Toast.LENGTH_SHORT).show();
-            }
-        });
+        sharedPreferences = PreferenceManager.getDefaultSharedPreferences(requireContext());
+        sharedPreferences.registerOnSharedPreferenceChangeListener(preferenceChangeListener);
 
-        binding.aiToggleSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
-            if (isAdded()) {
+        aiSwitchChangeListener = (buttonView, isChecked) -> {
+            if (sharedPreferences != null) {
+                sharedPreferences.edit().putBoolean(KEY_AI_TOGGLE_DEFAULT, isChecked).apply();
+            }
+            updateAiUi(isChecked);
+            if (isAdded() && !suppressAiToast) {
                 int messageRes = isChecked ? R.string.ai_enabled_message : R.string.ai_disabled_message;
                 Toast.makeText(requireContext(), messageRes, Toast.LENGTH_SHORT).show();
             }
+            suppressAiToast = false;
+        };
+
+        binding.aiToggleSwitch.setOnCheckedChangeListener(aiSwitchChangeListener);
+        binding.aiActionButton.setOnClickListener(v -> handleAiAction());
+        binding.discardPhotoButton.setOnClickListener(v -> {
+            clearCapturedPhoto();
+            if (isAdded()) {
+                Toast.makeText(requireContext(), R.string.photo_discarded_message, Toast.LENGTH_SHORT).show();
+            }
         });
+
+        binding.shutterButton.setOnClickListener(v -> takePhoto());
+
+        applyUserPreferences();
 
         ensureCameraPermission();
     }
 
     private void ensureCameraPermission() {
+        if (!isAdded()) {
+            return;
+        }
         if (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.CAMERA)
                 == PackageManager.PERMISSION_GRANTED) {
             startCamera();
@@ -86,15 +136,24 @@ public class HomeFragment extends Fragment {
             try {
                 ProcessCameraProvider cameraProvider = cameraProviderFuture.get();
 
+                int rotation = previewView.getDisplay() != null
+                        ? previewView.getDisplay().getRotation()
+                        : Surface.ROTATION_0;
+
                 Preview preview = new Preview.Builder().build();
                 preview.setSurfaceProvider(previewView.getSurfaceProvider());
+
+                imageCapture = new ImageCapture.Builder()
+                        .setCaptureMode(ImageCapture.CAPTURE_MODE_MINIMIZE_LATENCY)
+                        .setTargetRotation(rotation)
+                        .build();
 
                 CameraSelector cameraSelector = new CameraSelector.Builder()
                         .requireLensFacing(CameraSelector.LENS_FACING_BACK)
                         .build();
 
                 cameraProvider.unbindAll();
-                cameraProvider.bindToLifecycle(getViewLifecycleOwner(), cameraSelector, preview);
+                cameraProvider.bindToLifecycle(getViewLifecycleOwner(), cameraSelector, preview, imageCapture);
             } catch (ExecutionException e) {
                 if (isAdded()) {
                     Toast.makeText(requireContext(), e.getLocalizedMessage(), Toast.LENGTH_SHORT).show();
@@ -105,10 +164,198 @@ public class HomeFragment extends Fragment {
         }, ContextCompat.getMainExecutor(requireContext()));
     }
 
+    private void takePhoto() {
+        if (!isAdded()) {
+            return;
+        }
+        if (imageCapture == null) {
+            Toast.makeText(requireContext(), R.string.photo_capture_generic_error, Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        File outputDir = new File(requireContext().getCacheDir(), "captures");
+        if (!outputDir.exists() && !outputDir.mkdirs()) {
+            Toast.makeText(requireContext(), R.string.photo_capture_generic_error, Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        File photoFile;
+        try {
+            photoFile = File.createTempFile("feeloscope_", ".jpg", outputDir);
+        } catch (IOException e) {
+            String message = e.getLocalizedMessage();
+            if (message == null || message.isEmpty()) {
+                message = getString(R.string.photo_capture_generic_error);
+            } else {
+                message = getString(R.string.photo_capture_error, message);
+            }
+            Toast.makeText(requireContext(), message, Toast.LENGTH_LONG).show();
+            return;
+        }
+
+        ImageCapture.OutputFileOptions outputOptions = new ImageCapture.OutputFileOptions.Builder(photoFile).build();
+        imageCapture.takePicture(outputOptions, ContextCompat.getMainExecutor(requireContext()), new ImageCapture.OnImageSavedCallback() {
+            @Override
+            public void onImageSaved(@NonNull ImageCapture.OutputFileResults outputFileResults) {
+                deleteLastPhotoFile();
+                lastPhotoFile = photoFile;
+                if (isAdded()) {
+                    showCapturedPhoto(photoFile);
+                    Toast.makeText(requireContext(), R.string.photo_capture_success, Toast.LENGTH_SHORT).show();
+                    if (shouldAutoEnableAi() && binding != null && !binding.aiToggleSwitch.isChecked()) {
+                        suppressAiToast = true;
+                        binding.aiToggleSwitch.setChecked(true);
+                        Toast.makeText(requireContext(), R.string.ai_now_enabled_message, Toast.LENGTH_SHORT).show();
+                    }
+                }
+            }
+
+            @Override
+            public void onError(@NonNull ImageCaptureException exception) {
+                if (photoFile.exists()) {
+                    // Clean up file that could not be used
+                    //noinspection ResultOfMethodCallIgnored
+                    photoFile.delete();
+                }
+                if (isAdded()) {
+                    String message = exception.getLocalizedMessage();
+                    if (message == null || message.isEmpty()) {
+                        message = getString(R.string.photo_capture_generic_error);
+                    } else {
+                        message = getString(R.string.photo_capture_error, message);
+                    }
+                    Toast.makeText(requireContext(), message, Toast.LENGTH_LONG).show();
+                }
+            }
+        });
+    }
+
+    private void showCapturedPhoto(@NonNull File photoFile) {
+        if (binding == null) {
+            return;
+        }
+        Bitmap bitmap = decodeScaledBitmap(photoFile);
+        if (bitmap != null) {
+            binding.capturedPreviewImage.setImageBitmap(bitmap);
+            binding.capturePreviewCard.setVisibility(View.VISIBLE);
+            binding.capturedPreviewImage.setContentDescription(getString(R.string.captured_preview_description));
+        } else if (isAdded()) {
+            Toast.makeText(requireContext(), R.string.photo_capture_generic_error, Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    private Bitmap decodeScaledBitmap(@NonNull File file) {
+        BitmapFactory.Options options = new BitmapFactory.Options();
+        options.inJustDecodeBounds = true;
+        BitmapFactory.decodeFile(file.getAbsolutePath(), options);
+        options.inSampleSize = calculateInSampleSize(options, 1024, 1024);
+        options.inJustDecodeBounds = false;
+        return BitmapFactory.decodeFile(file.getAbsolutePath(), options);
+    }
+
+    private int calculateInSampleSize(@NonNull BitmapFactory.Options options, int reqWidth, int reqHeight) {
+        int height = options.outHeight;
+        int width = options.outWidth;
+        int inSampleSize = 1;
+
+        if (height > reqHeight || width > reqWidth) {
+            int halfHeight = height / 2;
+            int halfWidth = width / 2;
+
+            while ((halfHeight / inSampleSize) >= reqHeight && (halfWidth / inSampleSize) >= reqWidth) {
+                inSampleSize *= 2;
+            }
+        }
+        return Math.max(1, inSampleSize);
+    }
+
+    private void handleAiAction() {
+        if (binding == null || !isAdded()) {
+            return;
+        }
+        if (!binding.aiToggleSwitch.isChecked()) {
+            suppressAiToast = true;
+            binding.aiToggleSwitch.setChecked(true);
+            Toast.makeText(requireContext(), R.string.ai_now_enabled_message, Toast.LENGTH_SHORT).show();
+        } else {
+            Toast.makeText(requireContext(), R.string.ai_enabled_message, Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    private void clearCapturedPhoto() {
+        if (binding != null) {
+            binding.capturedPreviewImage.setImageDrawable(null);
+            binding.capturePreviewCard.setVisibility(View.GONE);
+        }
+        deleteLastPhotoFile();
+    }
+
+    private void deleteLastPhotoFile() {
+        if (lastPhotoFile != null && lastPhotoFile.exists()) {
+            //noinspection ResultOfMethodCallIgnored
+            lastPhotoFile.delete();
+        }
+        lastPhotoFile = null;
+    }
+
+    private void applyUserPreferences() {
+        applyAiDefault();
+        applyOverlayOpacity();
+    }
+
+    private void applyAiDefault() {
+        if (binding == null || sharedPreferences == null) {
+            return;
+        }
+        boolean aiEnabled = sharedPreferences.getBoolean(KEY_AI_TOGGLE_DEFAULT, false);
+        binding.aiToggleSwitch.setOnCheckedChangeListener(null);
+        binding.aiToggleSwitch.setChecked(aiEnabled);
+        updateAiUi(aiEnabled);
+        binding.aiToggleSwitch.setOnCheckedChangeListener(aiSwitchChangeListener);
+        suppressAiToast = false;
+    }
+
+    private void applyOverlayOpacity() {
+        if (binding == null || sharedPreferences == null) {
+            return;
+        }
+        int value = sharedPreferences.getInt(KEY_OVERLAY_OPACITY, DEFAULT_OVERLAY_OPACITY);
+        value = Math.max(40, Math.min(95, value));
+        int baseColor = ContextCompat.getColor(requireContext(), R.color.overlay_card_base);
+        int backgroundColor = ColorUtils.setAlphaComponent(baseColor, (int) (value / 100f * 255));
+        binding.topControls.setCardBackgroundColor(backgroundColor);
+        binding.bottomControls.setCardBackgroundColor(backgroundColor);
+        binding.capturePreviewCard.setCardBackgroundColor(backgroundColor);
+    }
+
+    private void updateAiUi(boolean isEnabled) {
+        if (binding == null) {
+            return;
+        }
+        binding.aiToggleIcon.setImageResource(isEnabled ? R.drawable.ic_sun : R.drawable.ic_moon);
+        binding.aiToggleSubtitle.setText(isEnabled
+                ? R.string.home_creative_toggle_hint_active
+                : R.string.home_creative_toggle_hint);
+    }
+
+    private boolean shouldAutoEnableAi() {
+        return sharedPreferences != null && sharedPreferences.getBoolean(KEY_AUTO_AI_AFTER_CAPTURE, true);
+    }
+
     @Override
     public void onDestroyView() {
         super.onDestroyView();
+        if (binding != null) {
+            binding.aiToggleSwitch.setOnCheckedChangeListener(null);
+        }
+        if (sharedPreferences != null) {
+            sharedPreferences.unregisterOnSharedPreferenceChangeListener(preferenceChangeListener);
+        }
+        clearCapturedPhoto();
         binding = null;
         cameraProviderFuture = null;
+        imageCapture = null;
+        sharedPreferences = null;
+        aiSwitchChangeListener = null;
     }
 }

--- a/app/src/main/res/color/nav_item_ripple.xml
+++ b/app/src/main/res/color/nav_item_ripple.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/nav_item_ripple_color" />
+</selector>

--- a/app/src/main/res/color/nav_item_tint.xml
+++ b/app/src/main/res/color/nav_item_tint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/primary_red" android:state_checked="true" />
+    <item android:color="@color/drawer_header_text_primary" android:state_pressed="true" />
+    <item android:color="@color/drawer_header_text_secondary" />
+</selector>

--- a/app/src/main/res/drawable/camera_shutter_inner.xml
+++ b/app/src/main/res/drawable/camera_shutter_inner.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval">
     <size android:width="70dp" android:height="70dp" />
-    <solid android:color="@android:color/white" />
+    <solid android:color="@color/shutter_inner" />
 </shape>

--- a/app/src/main/res/drawable/camera_shutter_outer.xml
+++ b/app/src/main/res/drawable/camera_shutter_outer.xml
@@ -5,5 +5,5 @@
     <solid android:color="@android:color/transparent" />
     <stroke
         android:width="4dp"
-        android:color="@android:color/white" />
+        android:color="@color/shutter_ring" />
 </shape>

--- a/app/src/main/res/drawable/ic_arrow_back.xml
+++ b/app/src/main/res/drawable/ic_arrow_back.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/primary_red"
+        android:pathData="M20,11H7.83l4.58,-4.59L11,5l-7,7 7,7 1.41,-1.41L7.83,13H20v-2z" />
+</vector>

--- a/app/src/main/res/drawable/nav_item_background.xml
+++ b/app/src/main/res/drawable/nav_item_background.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/nav_item_checked_background" />
+            <corners android:radius="28dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/transparent" />
+            <corners android:radius="28dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -19,7 +19,15 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="start"
+        android:background="?attr/colorSurface"
         android:fitsSystemWindows="true"
+        app:itemBackground="@drawable/nav_item_background"
+        app:itemHorizontalPadding="24dp"
+        app:itemIconPadding="0dp"
+        app:itemIconSize="28dp"
+        app:itemIconTint="@color/nav_item_tint"
+        app:itemRippleColor="@color/nav_item_ripple"
+        app:itemTextColor="@color/nav_item_tint"
         app:headerLayout="@layout/nav_header_main"
         app:menu="@menu/activity_main_drawer" />
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/settings_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorSurface"
+        android:elevation="4dp"
+        android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
+        app:navigationIcon="@drawable/ic_arrow_back"
+        app:title="@string/settings_title"
+        app:titleCentered="true" />
+
+    <FrameLayout
+        android:id="@+id/settings_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="?attr/actionBarSize" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -5,7 +5,9 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@android:color/black"
-    tools:context=".ui.home.HomeFragment">
+    app:layout_behavior="@string/appbar_scrolling_view_behavior"
+    tools:context=".ui.home.HomeFragment"
+    tools:showIn="@layout/app_bar_main">
 
     <androidx.camera.view.PreviewView
         android:id="@+id/camera_preview"
@@ -57,12 +59,13 @@
             android:paddingHorizontal="4dp">
 
             <ImageView
+                android:id="@+id/ai_toggle_icon"
                 android:layout_width="36dp"
                 android:layout_height="36dp"
-                android:contentDescription="@string/app_name"
+                android:contentDescription="@string/ai_toggle_label"
                 android:padding="4dp"
                 android:src="@drawable/ic_moon"
-                android:tint="@color/off_white" />
+                android:tint="@color/overlay_card_text_primary" />
 
             <LinearLayout
                 android:layout_width="0dp"
@@ -72,18 +75,20 @@
                 android:orientation="vertical">
 
                 <TextView
+                    android:id="@+id/ai_toggle_label"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/ai_toggle_label"
                     android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
-                    android:textColor="@color/off_white" />
+                    android:textColor="@color/overlay_card_text_primary" />
 
                 <TextView
+                    android:id="@+id/ai_toggle_subtitle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/home_creative_toggle_hint"
                     android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
-                    android:textColor="@color/overlay_card_stroke" />
+                    android:textColor="@color/overlay_card_text_secondary" />
             </LinearLayout>
 
             <com.google.android.material.switchmaterial.SwitchMaterial
@@ -92,8 +97,71 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="12dp"
                 android:checked="false"
-                android:textColor="@android:color/white"
                 app:useMaterialThemeColors="true" />
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/capture_preview_card"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="24dp"
+        android:layout_marginBottom="16dp"
+        android:padding="16dp"
+        android:visibility="gone"
+        app:cardBackgroundColor="@color/overlay_card_background"
+        app:cardCornerRadius="28dp"
+        app:cardElevation="8dp"
+        app:layout_constraintBottom_toTopOf="@+id/bottom_controls"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/top_controls"
+        app:strokeColor="@color/overlay_card_stroke"
+        app:strokeWidth="1dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/photo_preview_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/photo_preview_title"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
+                android:textColor="@color/overlay_card_text_primary" />
+
+            <ImageView
+                android:id="@+id/captured_preview_image"
+                android:layout_width="match_parent"
+                android:layout_height="220dp"
+                android:layout_marginTop="12dp"
+                android:background="@android:color/transparent"
+                android:contentDescription="@string/captured_preview_description"
+                android:scaleType="centerCrop" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/ai_action_button"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/photo_preview_ai_button"
+                android:textAllCaps="false"
+                android:textColor="@color/primary_red" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/discard_photo_button"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="@string/photo_preview_discard"
+                android:textAllCaps="false"
+                android:textColor="@color/overlay_card_text_secondary" />
         </LinearLayout>
     </com.google.android.material.card.MaterialCardView>
 
@@ -112,6 +180,8 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/capture_preview_card"
+        app:layout_constraintVertical_bias="1"
         app:strokeColor="@color/overlay_card_stroke"
         app:strokeWidth="1dp">
 
@@ -122,13 +192,14 @@
             android:orientation="vertical">
 
             <TextView
+                android:id="@+id/capture_prompt"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:gravity="center"
                 android:text="@string/home_capture_prompt"
                 android:textAlignment="center"
                 android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
-                android:textColor="@color/off_white" />
+                android:textColor="@color/overlay_card_text_primary" />
 
             <FrameLayout
                 android:id="@+id/shutter_button"
@@ -149,6 +220,7 @@
             </FrameLayout>
 
             <TextView
+                android:id="@+id/capture_hint"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="18dp"
@@ -157,7 +229,7 @@
                 android:text="@string/home_capture_hint"
                 android:textAlignment="center"
                 android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
-                android:textColor="@color/overlay_card_stroke" />
+                android:textColor="@color/overlay_card_text_secondary" />
         </LinearLayout>
     </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/layout/nav_header_main.xml
+++ b/app/src/main/res/layout/nav_header_main.xml
@@ -2,34 +2,63 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/nav_header_height"
+    android:layout_height="wrap_content"
     android:background="@drawable/side_nav_bar"
     android:gravity="center"
     android:orientation="vertical"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:theme="@style/ThemeOverlay.AppCompat.Dark">
+    android:padding="24dp">
 
-    <ImageView
-        android:id="@+id/imageView"
-        android:layout_width="120dp"
-        android:layout_height="120dp"
-        android:contentDescription="@string/nav_header_desc"
-        android:paddingTop="@dimen/nav_header_vertical_spacing"
-        app:srcCompat="@mipmap/ic_launcher_round" />
-
-    <TextView
+    <com.google.android.material.card.MaterialCardView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingTop="@dimen/nav_header_vertical_spacing"
-        android:text="@string/nav_header_title"
-        android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
+        android:layout_marginTop="12dp"
+        android:layout_marginBottom="12dp"
+        app:cardBackgroundColor="@color/drawer_header_background"
+        app:cardCornerRadius="24dp"
+        app:cardElevation="0dp">
 
-    <TextView
-        android:id="@+id/textView"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/nav_header_subtitle" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:orientation="vertical"
+            android:padding="20dp">
+
+            <ImageView
+                android:id="@+id/header_logo"
+                android:layout_width="120dp"
+                android:layout_height="120dp"
+                android:contentDescription="@string/nav_header_desc"
+                android:scaleType="fitCenter"
+                app:srcCompat="@drawable/ohm_logo_old" />
+
+            <TextView
+                android:id="@+id/header_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/nav_header_title"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Headline6"
+                android:textColor="@color/drawer_header_text_primary" />
+
+            <TextView
+                android:id="@+id/header_subtitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="@string/nav_header_subtitle"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+                android:textColor="@color/drawer_header_text_secondary" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/header_settings_button"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/nav_header_action"
+                android:textAllCaps="false"
+                android:textColor="@color/primary_red" />
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
 </LinearLayout>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="overlay_card_base">#FFFFFFFF</color>
+    <color name="overlay_card_background">#B3FFFFFF</color>
+    <color name="overlay_card_stroke">#33000000</color>
+    <color name="overlay_card_text_primary">#FF111111</color>
+    <color name="overlay_card_text_secondary">#AA111111</color>
+
+    <color name="drawer_header_background">#CC202020</color>
+    <color name="drawer_header_text_primary">#FFECECEC</color>
+    <color name="drawer_header_text_secondary">#FFBDBDBD</color>
+
+    <color name="nav_item_checked_background">#33FFFFFF</color>
+    <color name="nav_item_ripple_color">#4DFFFFFF</color>
+
+    <color name="shutter_ring">#FFFFFFFF</color>
+    <color name="shutter_inner">#FFECECEC</color>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,6 +7,20 @@
     <color name="dark_gray">#FF222222</color>
     <color name="off_white">#FFF5F5F5</color>
     <color name="white">#FFFFFFFF</color>
-    <color name="overlay_card_background">#CC1E1E1E</color>
+
+    <color name="overlay_card_base">#FF121212</color>
+    <color name="overlay_card_background">#B3121212</color>
     <color name="overlay_card_stroke">#66FFFFFF</color>
+    <color name="overlay_card_text_primary">#FFFFFFFF</color>
+    <color name="overlay_card_text_secondary">#B3FFFFFF</color>
+
+    <color name="drawer_header_background">#F2FFFFFF</color>
+    <color name="drawer_header_text_primary">#FF111111</color>
+    <color name="drawer_header_text_secondary">#FF444444</color>
+
+    <color name="nav_item_checked_background">#1AC62325</color>
+    <color name="nav_item_ripple_color">#33C62325</color>
+
+    <color name="shutter_ring">#FFFFFFFF</color>
+    <color name="shutter_inner">#FFFFFFFF</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,10 +2,11 @@
     <string name="app_name">FeelOScope</string>
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>
-    <string name="nav_header_title">Android Studio</string>
-    <string name="nav_header_subtitle">android.studio@android.com</string>
-    <string name="nav_header_desc">Navigation header</string>
-    <string name="action_settings">Settings</string>
+    <string name="nav_header_title">FeelOScope</string>
+    <string name="nav_header_subtitle">Emotionen neu gedacht.</string>
+    <string name="nav_header_desc">Menü-Kopfbereich von FeelOScope</string>
+    <string name="nav_header_action">Einstellungen öffnen</string>
+    <string name="action_settings">Einstellungen</string>
     <string name="toggle_theme">Toggle dark mode</string>
 
     <string name="menu_home">Kamera</string>
@@ -13,15 +14,24 @@
     <string name="menu_slideshow">deine Videos nutzen</string>
     <string name="ohm_logo_description">Technische Hochschule Nürnberg logo</string>
     <string name="ai_toggle_label">AI aktivieren</string>
-    <string name="home_creative_toggle_hint">Verleihe deinen Aufnahmen eine Portion Magie.</string>
+    <string name="home_creative_toggle_hint">Schalte die AI frei, um deine Aufnahmen zu veredeln.</string>
+    <string name="home_creative_toggle_hint_active">AI begleitet deine Aufnahme in Echtzeit.</string>
     <string name="camera_preview_description">Live-Vorschau der Kamera</string>
     <string name="shutter_button_description">Auslöser drücken, um ein Foto aufzunehmen</string>
     <string name="home_capture_prompt">Bereit, Emotionen einzufangen?</string>
     <string name="home_capture_hint">Tippe auf den leuchtenden Kreis, um deinen Moment festzuhalten.</string>
-    <string name="shutter_placeholder_message">Fotoaufnahme folgt in einem späteren Schritt.</string>
+    <string name="photo_capture_success">Foto aufgenommen.</string>
+    <string name="photo_capture_error">Das Foto konnte nicht gespeichert werden: %1$s</string>
+    <string name="photo_capture_generic_error">Die Fotoaufnahme ist fehlgeschlagen.</string>
+    <string name="photo_discarded_message">Vorschau verworfen.</string>
     <string name="camera_permission_denied">Kamerazugriff erforderlich, um die Vorschau anzuzeigen.</string>
     <string name="ai_enabled_message">AI-Unterstützung aktiviert.</string>
     <string name="ai_disabled_message">AI-Unterstützung deaktiviert.</string>
+    <string name="ai_now_enabled_message">AI-Unterstützung wird auf dieses Foto angewendet.</string>
+    <string name="captured_preview_description">Aufgenommenes Foto zur Vorschau</string>
+    <string name="photo_preview_title">Dein letzter Moment</string>
+    <string name="photo_preview_ai_button">AI für dieses Foto aktivieren</string>
+    <string name="photo_preview_discard">Foto verwerfen</string>
     <string name="gallery_instruction">Wähle ein Bild aus deiner Galerie aus, um es von der AI analysieren zu lassen.</string>
     <string name="gallery_select_button">Bild auswählen</string>
     <string name="gallery_selected_image_content_description">Ausgewähltes Bild für die Analyse</string>
@@ -38,4 +48,12 @@
     <string name="video_selected_content_description">Ausgewähltes Video für die Analyse</string>
     <string name="video_analysis_frame_missing">Das Video konnte nicht analysiert werden. Versuche ein anderes Video.</string>
     <string name="video_analysis_result_template">Analyse des ersten Frames: %1$s</string>
+    <string name="settings_title">Einstellungen</string>
+    <string name="pref_title_ai_default">AI beim Start aktivieren</string>
+    <string name="pref_summary_ai_default">Legt fest, ob der AI-Schalter direkt nach dem Start eingeschaltet ist.</string>
+    <string name="pref_title_auto_ai_after_capture">AI nach Aufnahme automatisch aktivieren</string>
+    <string name="pref_summary_auto_ai_after_capture">Aktiviere die AI-Unterstützung automatisch, sobald ein neues Foto aufgenommen wurde.</string>
+    <string name="pref_title_overlay_opacity">Deckkraft der Steuerkarten</string>
+    <string name="pref_summary_overlay_opacity">Bestimme, wie transparent die Steuerflächen über der Kamera sein sollen.</string>
+    <string name="pref_overlay_opacity_value">Aktuelle Deckkraft: %1$d%%</string>
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <SwitchPreferenceCompat
+        android:key="pref_ai_toggle_default"
+        android:title="@string/pref_title_ai_default"
+        android:summary="@string/pref_summary_ai_default"
+        android:defaultValue="false" />
+
+    <SwitchPreferenceCompat
+        android:key="pref_auto_ai_after_capture"
+        android:title="@string/pref_title_auto_ai_after_capture"
+        android:summary="@string/pref_summary_auto_ai_after_capture"
+        android:defaultValue="true" />
+
+    <SeekBarPreference
+        android:key="pref_overlay_opacity"
+        android:title="@string/pref_title_overlay_opacity"
+        android:summary="@string/pref_summary_overlay_opacity"
+        android:defaultValue="70"
+        android:min="40"
+        android:max="95"
+        android:seekBarIncrement="5"
+        app:showSeekBarValue="true" />
+
+</PreferenceScreen>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ navigationFragment = "2.6.0"
 navigationUi = "2.6.0"
 cameraX = "1.3.4"
 mlkitFaceDetection = "16.1.6"
+preference = "1.2.1"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -28,6 +29,7 @@ camera-camera2 = { group = "androidx.camera", name = "camera-camera2", version.r
 camera-lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "cameraX" }
 camera-view = { group = "androidx.camera", name = "camera-view", version.ref = "cameraX" }
 mlkit-face-detection = { group = "com.google.mlkit", name = "face-detection", version.ref = "mlkitFaceDetection" }
+preference = { group = "androidx.preference", name = "preference-ktx", version.ref = "preference" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- refresh the navigation drawer with modern styling, a settings shortcut, and the historic OHM logo
- add a dedicated settings screen for AI defaults and overlay transparency preferences
- upgrade the home camera flow to capture photos, show previews, and honour dark-mode friendly overlay styling

## Testing
- ./gradlew lint *(fails: Android SDK not available in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68da9ba340e08330aae7b3dd299f636c