### PR TITLE
Fix SeekBarPreference increment attribute

### DIFF
--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -21,7 +21,7 @@
         android:defaultValue="70"
         android:min="40"
         android:max="95"
-        android:seekBarIncrement="5"
+        app:seekBarIncrement="5"
         app:showSeekBarValue="true" />
 
 </PreferenceScreen>


### PR DESCRIPTION
## Summary
- replace the unsupported `android:seekBarIncrement` attribute on the settings SeekBarPreference with the compat namespace version so resources link correctly

## Testing
- `./gradlew assembleDebug` *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68daa0f5f2888330852b62738d22db9c