### PR TITLE
Adjust photo button spacing

### DIFF
--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -169,7 +169,7 @@
         android:id="@+id/bottom_controls"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="40dp"
+        android:layout_marginBottom="16dp"
         android:paddingStart="32dp"
         android:paddingTop="28dp"
         android:paddingEnd="32dp"


### PR DESCRIPTION
## Summary
- reduce the bottom margin of the capture controls card so the shutter button sits closer to the screen edge

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daa1e737f483309bba434f70ca9441